### PR TITLE
Add the packaging metadata to build the zcash-mini snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: zcash-mini
+version: master
+summary: A minimal portable Zcash z-address generator for offline / paper wallets
+description: |
+  zcash-mini is a minimal, portable Zcash wallet generator in Go.
+
+grade: devel
+confinement: strict
+
+apps:
+  zcash-mini:
+    command: zcash-mini
+
+parts:
+  zcash-mini:
+    source: .
+    plugin: go
+    go-importpath: github.com/FiloSottile/zcash-mini


### PR DESCRIPTION
This is a package for the secure installation of apps that works in Ubuntu and other Linux distributions.