### PR TITLE
Update to support the viewkey encodings in zcash/zips/#117

### DIFF
--- a/zcash/address.go
+++ b/zcash/address.go
@@ -100,6 +100,10 @@ func KeyToViewingKey(key []byte) ([]byte, error) {
 	viewKey := make([]byte, 64)
 	prfAddr(viewKey, key, 0)
 	prfAddr(viewKey[32:], key, 1)
+	//Clamp PRF output to a sections 4.2 and 5.4.6 of the Zcash spec
+	viewKey[32] &= 248
+	viewKey[63] &= 127
+	viewKey[63] |= 64
 	return viewKey, nil
 }
 

--- a/zcash/address.go
+++ b/zcash/address.go
@@ -100,7 +100,8 @@ func KeyToViewingKey(key []byte) ([]byte, error) {
 	viewKey := make([]byte, 64)
 	prfAddr(viewKey, key, 0)
 	prfAddr(viewKey[32:], key, 1)
-	//Clamp PRF output to a sections 4.2 and 5.4.6 of the Zcash spec
+	// Clamp PRF output to a valid Curve25519 secret key.
+	// (See sections 4.2 and 5.4.6 of the Zcash spec.)
 	viewKey[32] &= 248
 	viewKey[63] &= 127
 	viewKey[63] |= 64

--- a/zcash/address.go
+++ b/zcash/address.go
@@ -16,7 +16,8 @@ var (
 	TestSpendingKey = [2]byte{0xAC, 0x08}
 	ProdAddress     = [2]byte{0x16, 0x9A}
 	TestAddress     = [2]byte{0x16, 0xB6}
-	ProdViewingKey  = [2]byte{0, 0} // Not yet specified - WILL CHANGE
+	ProdViewingKey  = [2]byte{0x0B, 0x1C}
+	TestViewingKey  = [2]byte{0x0B, 0x2A}
 )
 
 var (
@@ -96,8 +97,9 @@ func KeyToViewingKey(key []byte) ([]byte, error) {
 	if len(key) != 32 || key[0]&0xf0 != 0 {
 		return nil, ErrInvalidKey
 	}
-	viewKey := make([]byte, 32)
-	prfAddr(viewKey, key, 1)
+	viewKey := make([]byte, 64)
+	prfAddr(viewKey, key, 0)
+	prfAddr(viewKey[32:], key, 1)
 	return viewKey, nil
 }
 


### PR DESCRIPTION
There is now a specification for serialized viewing keys. Updated to conform to it.
https://github.com/zcash/zips/pull/117